### PR TITLE
适配当前居住状态一选项

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ if __name__ == '__main__':
 	# report
 	data = {
 		'ismoved': '0',
+		'dqjzzt': '1',  # 当前居住状态，0在校、1在京不在校
 		'jhfjrq': '',  # 计划返京日期
 		'jhfjjtgj': '',  # 计划返京交通工具
 		'jhfjhbcc': '',  # 计划返京航班车次


### PR DESCRIPTION
明日起新增 “居住状态一选项” 一项，故更新脚本以适配

> 【温馨提示】各位同学，下周疫情通即将正式上线，麻烦请大家务必每天15:00前提交，认真按照真实情况线上填报，尤其是居住状态，不要总选择默认的“一直住校”哈，明天会增加“今日返京”的选项，请一定认真填写哈，同时还有您的个人信息，如果有误，请务必今天与我联系，涉及信息真实上报，严禁漏报，谎报，感谢大家一直以来的支持，辛苦了